### PR TITLE
Adding gfp/prettier configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.4.0
+
+* Added React Native support
+
 ### 4.3.2
  * Fixed bugs with Jest configuration and added react/jsx-uses-react for React configuration
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ This is the config used for all products based on the Green Frontend platform.
 	    "extends": "gfp/jest"
 	}
 	```
+	
+	If you are using **Prettier** with any of our eslint configurations, add:
+	```
+	{
+	    "extends": "gfp/prettier"
+	}
+	```
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ This is the config used for all products based on the Green Frontend platform.
 	    "extends": "gfp/react"
 	}
 	```
+
+    To use our **React Native JS rules** (including JSX support), use:
+	```
+	{
+	    "extends": "gfp/react-native"
+	}
+	```
 	
 	To use our **Jest JS rules**, use:
 	```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "eslint-config-airbnb-base": "^11.2.0",
+        "eslint-config-prettier": "^4.1.0",
         "eslint-plugin-angular": "^2.5.0",
         "eslint-plugin-import": "^2.2.0",
         "eslint-plugin-jasmine": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-config-gfp",
-    "version": "4.3.2",
+    "version": "4.4.0",
     "description": "The config used for all products based on the Green Frontend platform",
     "keywords": [
         "eslint",
@@ -27,6 +27,7 @@
         "eslint-plugin-jest": "^21.18.0",
         "eslint-plugin-jsx-a11y": "^2.2.3",
         "eslint-plugin-protractor": "^1.40.0",
-        "eslint-plugin-react": "^7.10.0"
+        "eslint-plugin-react": "^7.10.0",
+        "eslint-plugin-react-native": "^3.6.0"
     }
 }

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,6 @@
+module.exports = {
+    'extends': [
+        'prettier',
+        'prettier/react'
+    ]
+};

--- a/react-native.js
+++ b/react-native.js
@@ -1,0 +1,23 @@
+module.exports = {
+    'env': {
+        'node': false,
+        'es6': true,
+        'browser': false,
+        'react-native/react-native': true
+    },
+    'plugins': [
+        'react',
+        'react-native'
+    ],
+    'extends': [
+        'airbnb-base/legacy',
+        'gfp/rules/base',
+        'gfp/rules/es6',
+        'gfp/react'
+    ],
+    rules: {
+        'react-native/no-unused-styles': 2,
+        'react-native/sort-styles': 2,
+        'react-native/no-inline-styles': 2
+    }
+};


### PR DESCRIPTION
This PR fixes 2 things:

1) master branch in the repo is not in sync with the latest version in npm (v4.4.0). The changes from v4.4.0 are in this PR as well to get them merged into master

2) Added `prettier.js` that fixes configuration conflicts with prettier by using `eslint-config-prettier`
To use it add  to your eslint config:
```
extends: [
   // other configs
   'gfp/prettier'
]
```