### PR TITLE
undefined Need to lock down to patches since eslint-plugin-react v7.1…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
-    "name": "eslint-config-gfp",
-    "version": "4.5.1",
-    "description": "The config used for all products based on the Green Frontend platform",
-    "keywords": [
-        "eslint",
-        "eslintconfig"
-    ],
-    "main": ".eslintrc",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/mrgreentech/eslint-config-gfp.git"
-    },
-    "author": "Simon Auner <simon.auner@mrgreen.com>",
-    "license": "ISC",
-    "peerDependencies": {
-        "eslint": ">= 3"
-    },
-    "dependencies": {
-        "babel-eslint": "^10.0.1",
-        "eslint-config-airbnb-base": "^11.2.0",
-        "eslint-config-prettier": "^4.1.0",
-        "eslint-plugin-angular": "^2.5.0",
-        "eslint-plugin-import": "^2.2.0",
-        "eslint-plugin-jasmine": "^2.3.1",
-        "eslint-plugin-jest": "^21.18.0",
-        "eslint-plugin-jsx-a11y": "^2.2.3",
-        "eslint-plugin-protractor": "^1.40.0",
-        "eslint-plugin-react": "^7.10.0",
-        "eslint-plugin-react-native": "^3.6.0"
-    }
+	"name": "eslint-config-gfp",
+	"version": "4.5.1",
+	"description": "The config used for all products based on the Green Frontend platform",
+	"keywords": [
+		"eslint",
+		"eslintconfig"
+	],
+	"main": ".eslintrc",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/mrgreentech/eslint-config-gfp.git"
+	},
+	"author": "Simon Auner <simon.auner@mrgreen.com>",
+	"license": "ISC",
+	"peerDependencies": {
+		"eslint": ">= 3"
+	},
+	"dependencies": {
+		"babel-eslint": "~10.0.1",
+		"eslint-config-airbnb-base": "~11.2.0",
+		"eslint-config-prettier": "~4.1.0",
+		"eslint-plugin-angular": "~2.5.0",
+		"eslint-plugin-import": "~2.2.0",
+		"eslint-plugin-jasmine": "~2.3.1",
+		"eslint-plugin-jest": "~21.18.0",
+		"eslint-plugin-jsx-a11y": "~2.2.3",
+		"eslint-plugin-protractor": "~1.40.0",
+		"eslint-plugin-react": "~7.16.0",
+		"eslint-plugin-react-native": "~3.6.0"
+	}
 }


### PR DESCRIPTION
…7.0 introduced eslint-plugin-eslint-plugin which does not suport node v6.9.5, which we are forced to use in TeamCity.